### PR TITLE
Changing property names to camelCase

### DIFF
--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.commons/src/main/java/org/wso2/carbon/cluster/coordinator/commons/configs/CoordinationPropertyNames.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.commons/src/main/java/org/wso2/carbon/cluster/coordinator/commons/configs/CoordinationPropertyNames.java
@@ -22,11 +22,11 @@ public class CoordinationPropertyNames {
 
     public static final String CLUSTER_CONFIG_NS = "cluster.config";
 
-    public static final String STRATEGY_CONFIG_NS = "strategy.config";
+    public static final String STRATEGY_CONFIG_NS = "strategyConfig";
 
-    public static final String COORDINATION_STRATEGY_CLASS_PROPERTY = "coordination.strategy.class";
+    public static final String COORDINATION_STRATEGY_CLASS_PROPERTY = "coordinationStrategyClass";
 
-    public static final String GROUP_ID_PROPERTY = "group.id";
+    public static final String GROUP_ID_PROPERTY = "groupId";
 
     public static final String ENABLED_PROPERTY = "enabled";
 

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/util/RDBMSConstants.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/util/RDBMSConstants.java
@@ -214,11 +214,11 @@ public class RDBMSConstants {
 
     public static final String RDBMS_COORDINATION_DS = "datasource";
 
-    public static final String HEART_BEAT_INTERVAL = "heart.beat.interval";
+    public static final String HEART_BEAT_INTERVAL = "heartbeatInterval";
 
-    public static final String EVENT_POLLING_INTERVAL = "event.polling.interval";
+    public static final String EVENT_POLLING_INTERVAL = "eventPollingInterval";
 
-    public static final String HEART_BEAT_MAX_AGE = "heart.beat.max.age";
+    public static final String HEART_BEAT_MAX_AGE = "heartbeatMaxAge";
 
     /**
      * Only public static constants are in this class. No need to instantiate.

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deployment.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deployment.yaml
@@ -197,11 +197,10 @@ state.persistence:
 
 cluster.config:
   enabled: true
-  group.id: testGroupOne
-  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
-
-  strategy.config:
+  groupId: testGroupOne
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
     datasource: WSO2_CLUSTER_DB
-    heart.beat.interval: 1000
-    heart.beat.max.age: 2
-    event.polling.interval: 1000
+    heartbeatInterval: 1000
+    heartbeatMaxAge: 2
+    eventPollingInterval: 1000

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.zookeeper/src/test/resources/conf/deployment.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.zookeeper/src/test/resources/conf/deployment.yaml
@@ -197,10 +197,10 @@ state.persistence:
 
 cluster.config:
   enabled: true
-  group.id: ha
-  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
-  strategy.config:
+  groupId: ha
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
     datasource: WSO2_CLUSTER_DB
-    heart.beat.interval: 1000
-    heart.beat.max.age: 2
-    event.polling.interval: 1000
+    heartbeatInterval: 1000
+    heartbeatMaxAge: 2
+    eventPollingInterval: 1000


### PR DESCRIPTION
## Purpose
> Currently, Carbon-config doesn't support unmarshalling '.' delimited property names. Therefore, changing such property names to camelCase.