### PR TITLE
Bump guava version to 20.0

### DIFF
--- a/features/cluster-coordinator/org.wso2.carbon.cluster.coordinator.rdbms.feature/pom.xml
+++ b/features/cluster-coordinator/org.wso2.carbon.cluster.coordinator.rdbms.feature/pom.xml
@@ -17,6 +17,10 @@
             <groupId>org.wso2.carbon.coordination</groupId>
             <artifactId>org.wso2.carbon.cluster.coordinator.rdbms</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -74,6 +78,10 @@
                                 </advice>
                             </adviceFileContents>
                             <bundles>
+                                <bundle>
+                                    <symbolicName>com.google.guava</symbolicName>
+                                    <version>${guava.bundle.version}</version>
+                                </bundle>
                                 <bundle>
                                     <symbolicName>org.wso2.carbon.cluster.coordinator.rdbms</symbolicName>
                                     <version>${project.parent.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -289,8 +289,9 @@
         <carbon.datasources.version>1.1.2</carbon.datasources.version>
         <commons.logging.version>1.2</commons.logging.version>
         <commons.logging.imp.package.version>[1.2,2.0)</commons.logging.imp.package.version>
-        <guava.version>19.0</guava.version>
-        <guava.imp.package.version>[19.0,20.0)</guava.imp.package.version>
+        <guava.version>20.0</guava.version>
+        <guava.bundle.version>20.0.0</guava.bundle.version>
+        <guava.imp.package.version>[20.0.0,21.0.0)</guava.imp.package.version>
         <apache.curator.imp.package.version>[2.6.0,2.9.0)</apache.curator.imp.package.version>
         <com.h2database.version>1.4.187</com.h2database.version>
         <org.testing.version>6.9.10</org.testing.version>


### PR DESCRIPTION
## Purpose
> Earlier the guava version we had was 19.0. However, in SP 4.0.0 we have
guava 20.0. Therefore, bumping guava version/version range to work with
guava 20.0.

## Goals
> Making carbon-coordination compatible with product SP 4.0.0