### PR TITLE
RDBMS Service registration depends on configuration + Added Testcases

### DIFF
--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
@@ -610,6 +610,9 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
         PreparedStatement preparedStatement = null;
         ResultSet resultSet = null;
         String coordinatorNodeId = getCoordinatorNodeId(groupId);
+        if (coordinatorNodeId == null) {
+            coordinatorNodeId = getCoordinatorNodeId(groupId);
+        }
         ArrayList<NodeDetail> nodeDataList = new ArrayList<NodeDetail>();
 
         try {
@@ -765,6 +768,9 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
         PreparedStatement preparedStatement = null;
         ResultSet resultSet = null;
         String coordinatorNodeId = getCoordinatorNodeId(groupId);
+        if (coordinatorNodeId == null) {
+            coordinatorNodeId = getCoordinatorNodeId(groupId);
+        }
         NodeDetail nodeDetail = null;
 
         try {
@@ -775,7 +781,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             resultSet = preparedStatement.executeQuery();
             Map<String, Object> propertiesMap = null;
             if (resultSet.next()) {
-                boolean isCoordinatorNode = coordinatorNodeId.equals(nodeId);
+                boolean isCoordinatorNode = nodeId.equals(coordinatorNodeId);
                 if (resultSet.getBlob(3) != null) {
                     int blobLength = (int) resultSet.getBlob(3).length();
                     byte[] bytes = resultSet.getBlob(3).getBytes(1L, blobLength);

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCoordinationStrategy.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCoordinationStrategy.java
@@ -174,8 +174,11 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
     }
 
     @Override
-    public boolean isLeaderNode() {
+    public boolean isLeaderNode() throws ClusterCoordinationException {
         NodeDetail nodeDetail = communicationBusContext.getNodeData(localNodeId, localGroupId);
+        if (nodeDetail == null) {
+            nodeDetail = communicationBusContext.getNodeData(localNodeId, localGroupId);
+        }
         return nodeDetail.isCoordinator();
     }
 

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/internal/RDBMSCoordinationServiceComponent.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/internal/RDBMSCoordinationServiceComponent.java
@@ -85,8 +85,8 @@ public class RDBMSCoordinationServiceComponent {
                         clusterConfiguration.get(CoordinationPropertyNames.COORDINATION_STRATEGY_CLASS_PROPERTY));
             }
         } else {
-            log.warn("Cluster Coordination has been disabled. Enable it in deployment.yaml " +
-                    "to use the clustering service.");
+            log.info("Cluster Coordination has been disabled. Enable it in deployment.yaml " +
+                    "to use the clustering service for ");
         }
     }
 

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/internal/RDBMSCoordinationServiceComponent.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/internal/RDBMSCoordinationServiceComponent.java
@@ -26,7 +26,6 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.cluster.coordinator.commons.CoordinationStrategy;
 import org.wso2.carbon.cluster.coordinator.commons.configs.CoordinationPropertyNames;
-import org.wso2.carbon.cluster.coordinator.commons.exception.ClusterCoordinationException;
 import org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
@@ -62,12 +61,18 @@ public class RDBMSCoordinationServiceComponent {
             if (clusterConfiguration != null) {
                 RDBMSCoordinationServiceHolder.setClusterConfiguration(clusterConfiguration);
             } else {
-                throw new ClusterCoordinationException("Configurations for cluster coordination is not " +
-                        "available in deployment.yaml");
+                if (log.isDebugEnabled()) {
+                    log.debug(RDBMSCoordinationStrategy.class.getCanonicalName() + " will not be activated because " +
+                            "no configurations found");
+                }
+                return;
             }
         } catch (ConfigurationException e) {
-            throw new ClusterCoordinationException("Error in reading the cluster coordination configurations " +
-                    "from deployment.yaml");
+            if (log.isDebugEnabled()) {
+                log.debug(RDBMSCoordinationStrategy.class.getCanonicalName() + " will not be activated because " +
+                        "no configurations found");
+            }
+            return;
         }
         if ((Boolean) clusterConfiguration.get(CoordinationPropertyNames.ENABLED_PROPERTY)) {
             if (clusterConfiguration.get(CoordinationPropertyNames.COORDINATION_STRATEGY_CLASS_PROPERTY).

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinationEventFlowTestCase.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinationEventFlowTestCase.java
@@ -23,25 +23,27 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.cluster.coordinator.commons.node.NodeDetail;
 import org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-public class CoordinationEventFlowTestCase extends RDBMSCoordinationStratergyBaseTest {
-    RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne;
-    RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeTwo;
-    RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeThree;
-    EventListener eventListener;
+public class CoordinationEventFlowTestCase {
+    private RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne;
+    private RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeTwo;
+    private RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeThree;
+    private EventListener eventListener;
 
     private static final Log log = LogFactory.getLog(CoordinationEventFlowTestCase.class);
 
     @BeforeClass
     public void initialize() throws InterruptedException, FileNotFoundException {
-        init();
-        rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy(dataSource);
-        rdbmsCoordinationStrategyNodeTwo = new RDBMSCoordinationStrategy(dataSource);
-        rdbmsCoordinationStrategyNodeThree = new RDBMSCoordinationStrategy(dataSource);
+        Thread.sleep(2000);
+        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentOne.yaml", "dbOne");
+        rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy(RDBMSCoordinationStrategyUtil.dataSource);
+        rdbmsCoordinationStrategyNodeTwo = new RDBMSCoordinationStrategy(RDBMSCoordinationStrategyUtil.dataSource);
+        rdbmsCoordinationStrategyNodeThree = new RDBMSCoordinationStrategy(RDBMSCoordinationStrategyUtil.dataSource);
         eventListener = new EventListener();
     }
 
@@ -154,7 +156,8 @@ public class CoordinationEventFlowTestCase extends RDBMSCoordinationStratergyBas
     public void testCoordinatorChanged() throws InterruptedException {
         int count;
         String leaderId = null;
-        RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeFour = new RDBMSCoordinationStrategy(dataSource);
+        RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeFour = new RDBMSCoordinationStrategy(
+                RDBMSCoordinationStrategyUtil.dataSource);
         Map<String, Object> nodeFourPropertyMap = new HashMap<>();
         nodeFourPropertyMap.put("id", "node4");
         rdbmsCoordinationStrategyNodeFour.joinGroup();

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigDatasourceTestCase.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigDatasourceTestCase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.cluster.coordinator.rdbms.test;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.cluster.coordinator.commons.exception.ClusterCoordinationException;
+import org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy;
+
+import java.io.File;
+
+public class CoordinatorConfigDatasourceTestCase {
+
+    @Test(expectedExceptions = ClusterCoordinationException.class)
+    public void testDatasourceNotDefined() throws InterruptedException {
+        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentTwo.yaml", "dbTwo");
+        RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy();
+        rdbmsCoordinationStrategyNodeOne.joinGroup();
+    }
+}

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigDefaultValuesTestCase.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigDefaultValuesTestCase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.cluster.coordinator.rdbms.test;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy;
+
+import java.io.File;
+
+public class CoordinatorConfigDefaultValuesTestCase {
+
+    @Test
+    public void testDefaultValues() throws InterruptedException {
+        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentFour.yaml", "dbThree");
+        RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy(
+                RDBMSCoordinationStrategyUtil.dataSource);
+        rdbmsCoordinationStrategyNodeOne.joinGroup();
+        Thread.sleep(1000);
+        Assert.assertEquals(rdbmsCoordinationStrategyNodeOne.getAllNodeDetails().size(), 1);
+    }
+}

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigDefaultValuesTestCase.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigDefaultValuesTestCase.java
@@ -25,7 +25,7 @@ public class CoordinatorConfigDefaultValuesTestCase {
 
     @Test
     public void testDefaultValues() throws InterruptedException {
-        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentFour.yaml", "dbThree");
+        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentFour.yaml", "dbFour");
         RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy(
                 RDBMSCoordinationStrategyUtil.dataSource);
         rdbmsCoordinationStrategyNodeOne.joinGroup();

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigEmptyValuesTestCase.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigEmptyValuesTestCase.java
@@ -25,7 +25,7 @@ public class CoordinatorConfigEmptyValuesTestCase {
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testEmptyValues() throws InterruptedException {
-        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentFive.yaml", "dbFour");
+        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentFive.yaml", "dbFive");
         RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy(
                 RDBMSCoordinationStrategyUtil.dataSource);
         rdbmsCoordinationStrategyNodeOne.joinGroup();

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigEmptyValuesTestCase.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigEmptyValuesTestCase.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.cluster.coordinator.rdbms.test;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy;
+
+import java.io.File;
+
+public class CoordinatorConfigEmptyValuesTestCase {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testEmptyValues() throws InterruptedException {
+        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentFive.yaml", "dbFour");
+        RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy(
+                RDBMSCoordinationStrategyUtil.dataSource);
+        rdbmsCoordinationStrategyNodeOne.joinGroup();
+        Assert.assertEquals(rdbmsCoordinationStrategyNodeOne.getAllNodeDetails().size(), 1);
+    }
+}

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigGroupIdTestCase.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigGroupIdTestCase.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.cluster.coordinator.rdbms.test;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.cluster.coordinator.commons.exception.ClusterCoordinationException;
+import org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy;
+
+import java.io.File;
+
+public class CoordinatorConfigGroupIdTestCase {
+
+    @Test(expectedExceptions = ClusterCoordinationException.class)
+    public void testGroupIdNotDefined() throws InterruptedException {
+        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentThree.yaml", "dbFive");
+        RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy(
+                RDBMSCoordinationStrategyUtil.dataSource);
+        rdbmsCoordinationStrategyNodeOne.joinGroup();
+    }
+}

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigGroupIdTestCase.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/java/org/wso2/carbon/cluster/coordinator/rdbms/test/CoordinatorConfigGroupIdTestCase.java
@@ -25,7 +25,7 @@ public class CoordinatorConfigGroupIdTestCase {
 
     @Test(expectedExceptions = ClusterCoordinationException.class)
     public void testGroupIdNotDefined() throws InterruptedException {
-        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentThree.yaml", "dbFive");
+        RDBMSCoordinationStrategyUtil.init("conf" + File.separator + "deploymentThree.yaml", "dbThree");
         RDBMSCoordinationStrategy rdbmsCoordinationStrategyNodeOne = new RDBMSCoordinationStrategy(
                 RDBMSCoordinationStrategyUtil.dataSource);
         rdbmsCoordinationStrategyNodeOne.joinGroup();

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFive.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFive.yaml
@@ -197,10 +197,10 @@ state.persistence:
 
 cluster.config:
   enabled: true
-  group.id: testGroupOne
-  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
-  strategy.config:
+  groupId: testGroupOne
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
     datasource: WSO2_CLUSTER_DB
-    heart.beat.interval:
-    heart.beat.max.age:
-    event.polling.interval:
+    heartbeatInterval:
+    heartbeatMaxAge:
+    eventPollingInterval:

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFive.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFive.yaml
@@ -182,25 +182,12 @@ wso2.artifact.deployment:
     # Scheduler update interval
   updateInterval: 5
 
-
-  # HA Configuration
-state.persistence:
-  enabled: false
-  intervalInMin: 1
-  revisionsToKeep: 3
-  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
-  # config:
-    # location: siddhi-app-persistence
-  config:
-    datasource: WSO2_ANALYTICS_DB
-    table: PERSISTENCE_TABLE
-
 cluster.config:
   enabled: true
   groupId: testGroupOne
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
-    datasource: WSO2_CLUSTER_DB
+    datasource: WSO2_CLUSTER_DB  # Datasource is not defined in yaml since test cases will internally create datasource
     heartbeatInterval:
     heartbeatMaxAge:
     eventPollingInterval:

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFive.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFive.yaml
@@ -1,0 +1,206 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 0
+
+  # Configuration used for the databridge communication
+databridge.config:
+    # No of worker threads to consume events
+    # THIS IS A MANDATORY FIELD
+  workerThreads: 10
+    # Maximum amount of messages that can be queued internally in MB
+    # THIS IS A MANDATORY FIELD
+  maxEventBufferCapacity: 10000000
+    # Queue size; the maximum number of events that can be stored in the queue
+    # THIS IS A MANDATORY FIELD
+  eventBufferSize: 2000
+    # Keystore file path
+    # THIS IS A MANDATORY FIELD
+  keyStoreLocation : ${carbon.home}/resources/security/wso2carbon.jks
+    # Keystore password
+    # THIS IS A MANDATORY FIELD
+  keyStorePassword : wso2carbon
+    # Session Timeout value in mins
+    # THIS IS A MANDATORY FIELD
+  clientTimeoutMin: 30
+    # Data receiver configurations
+    # THIS IS A MANDATORY FIELD
+  dataReceivers:
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Thrift
+        # Data receiver properties
+      properties:
+        tcpPort: '7611'
+        sslPort: '7711'
+
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Binary
+        # Data receiver properties
+      properties:
+        tcpPort: '9611'
+        sslPort: '9711'
+        tcpReceiverThreadPoolSize: '100'
+        sslReceiverThreadPoolSize: '100'
+        hostName: 0.0.0.0
+
+  # Configuration of the Data Agents - to publish events through databridge
+data.agent.config:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+  agents:
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Thrift
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Binary
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+
+  # Deployment configuration parameters
+wso2.artifact.deployment:
+    # Scheduler update interval
+  updateInterval: 5
+
+
+  # HA Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 3
+  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
+  # config:
+    # location: siddhi-app-persistence
+  config:
+    datasource: WSO2_ANALYTICS_DB
+    table: PERSISTENCE_TABLE
+
+cluster.config:
+  enabled: true
+  group.id: testGroupOne
+  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategy.config:
+    datasource: WSO2_CLUSTER_DB
+    heart.beat.interval:
+    heart.beat.max.age:
+    event.polling.interval:

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFour.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFour.yaml
@@ -197,7 +197,7 @@ state.persistence:
 
 cluster.config:
   enabled: true
-  group.id: testGroupOne
-  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
-  strategy.config:
+  groupId: testGroupOne
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
     datasource: WSO2_CLUSTER_DB

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFour.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFour.yaml
@@ -182,22 +182,9 @@ wso2.artifact.deployment:
     # Scheduler update interval
   updateInterval: 5
 
-
-  # HA Configuration
-state.persistence:
-  enabled: false
-  intervalInMin: 1
-  revisionsToKeep: 3
-  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
-  # config:
-    # location: siddhi-app-persistence
-  config:
-    datasource: WSO2_ANALYTICS_DB
-    table: PERSISTENCE_TABLE
-
 cluster.config:
   enabled: true
   groupId: testGroupOne
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
-    datasource: WSO2_CLUSTER_DB
+    datasource: WSO2_CLUSTER_DB  # Datasource is not defined in yaml since test cases will internally create datasource

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFour.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentFour.yaml
@@ -1,0 +1,203 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 0
+
+  # Configuration used for the databridge communication
+databridge.config:
+    # No of worker threads to consume events
+    # THIS IS A MANDATORY FIELD
+  workerThreads: 10
+    # Maximum amount of messages that can be queued internally in MB
+    # THIS IS A MANDATORY FIELD
+  maxEventBufferCapacity: 10000000
+    # Queue size; the maximum number of events that can be stored in the queue
+    # THIS IS A MANDATORY FIELD
+  eventBufferSize: 2000
+    # Keystore file path
+    # THIS IS A MANDATORY FIELD
+  keyStoreLocation : ${carbon.home}/resources/security/wso2carbon.jks
+    # Keystore password
+    # THIS IS A MANDATORY FIELD
+  keyStorePassword : wso2carbon
+    # Session Timeout value in mins
+    # THIS IS A MANDATORY FIELD
+  clientTimeoutMin: 30
+    # Data receiver configurations
+    # THIS IS A MANDATORY FIELD
+  dataReceivers:
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Thrift
+        # Data receiver properties
+      properties:
+        tcpPort: '7611'
+        sslPort: '7711'
+
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Binary
+        # Data receiver properties
+      properties:
+        tcpPort: '9611'
+        sslPort: '9711'
+        tcpReceiverThreadPoolSize: '100'
+        sslReceiverThreadPoolSize: '100'
+        hostName: 0.0.0.0
+
+  # Configuration of the Data Agents - to publish events through databridge
+data.agent.config:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+  agents:
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Thrift
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Binary
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+
+  # Deployment configuration parameters
+wso2.artifact.deployment:
+    # Scheduler update interval
+  updateInterval: 5
+
+
+  # HA Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 3
+  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
+  # config:
+    # location: siddhi-app-persistence
+  config:
+    datasource: WSO2_ANALYTICS_DB
+    table: PERSISTENCE_TABLE
+
+cluster.config:
+  enabled: true
+  group.id: testGroupOne
+  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategy.config:
+    datasource: WSO2_CLUSTER_DB

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentOne.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentOne.yaml
@@ -182,25 +182,12 @@ wso2.artifact.deployment:
     # Scheduler update interval
   updateInterval: 5
 
-
-  # HA Configuration
-state.persistence:
-  enabled: false
-  intervalInMin: 1
-  revisionsToKeep: 3
-  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
-  # config:
-    # location: siddhi-app-persistence
-  config:
-    datasource: WSO2_ANALYTICS_DB
-    table: PERSISTENCE_TABLE
-
 cluster.config:
   enabled: true
   groupId: testGroupOne
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
-    datasource: WSO2_CLUSTER_DB
+    datasource: WSO2_CLUSTER_DB  # Datasource is not defined in yaml since test cases will internally create datasource
     heartbeatInterval: 1000
     heartbeatMaxAge: 2
     eventPollingInterval: 1000

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentOne.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentOne.yaml
@@ -199,7 +199,6 @@ cluster.config:
   enabled: true
   group.id: testGroupOne
   coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
-
   strategy.config:
     datasource: WSO2_CLUSTER_DB
     heart.beat.interval: 1000

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentThree.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentThree.yaml
@@ -1,0 +1,205 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 0
+
+  # Configuration used for the databridge communication
+databridge.config:
+    # No of worker threads to consume events
+    # THIS IS A MANDATORY FIELD
+  workerThreads: 10
+    # Maximum amount of messages that can be queued internally in MB
+    # THIS IS A MANDATORY FIELD
+  maxEventBufferCapacity: 10000000
+    # Queue size; the maximum number of events that can be stored in the queue
+    # THIS IS A MANDATORY FIELD
+  eventBufferSize: 2000
+    # Keystore file path
+    # THIS IS A MANDATORY FIELD
+  keyStoreLocation : ${carbon.home}/resources/security/wso2carbon.jks
+    # Keystore password
+    # THIS IS A MANDATORY FIELD
+  keyStorePassword : wso2carbon
+    # Session Timeout value in mins
+    # THIS IS A MANDATORY FIELD
+  clientTimeoutMin: 30
+    # Data receiver configurations
+    # THIS IS A MANDATORY FIELD
+  dataReceivers:
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Thrift
+        # Data receiver properties
+      properties:
+        tcpPort: '7611'
+        sslPort: '7711'
+
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Binary
+        # Data receiver properties
+      properties:
+        tcpPort: '9611'
+        sslPort: '9711'
+        tcpReceiverThreadPoolSize: '100'
+        sslReceiverThreadPoolSize: '100'
+        hostName: 0.0.0.0
+
+  # Configuration of the Data Agents - to publish events through databridge
+data.agent.config:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+  agents:
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Thrift
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Binary
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+
+  # Deployment configuration parameters
+wso2.artifact.deployment:
+    # Scheduler update interval
+  updateInterval: 5
+
+
+  # HA Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 3
+  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
+  # config:
+    # location: siddhi-app-persistence
+  config:
+    datasource: WSO2_ANALYTICS_DB
+    table: PERSISTENCE_TABLE
+
+cluster.config:
+  enabled: true
+  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategy.config:
+    datasource: WSO2_CLUSTER_DB
+    heart.beat.interval: 100
+    heart.beat.max.age: 2
+    event.polling.interval: 500

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentThree.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentThree.yaml
@@ -197,9 +197,9 @@ state.persistence:
 
 cluster.config:
   enabled: true
-  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
-  strategy.config:
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
     datasource: WSO2_CLUSTER_DB
-    heart.beat.interval: 100
-    heart.beat.max.age: 2
-    event.polling.interval: 500
+    heartbeatInterval: 1000
+    heartbeatMaxAge: 2
+    eventPollingInterval: 1000

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentThree.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentThree.yaml
@@ -182,24 +182,11 @@ wso2.artifact.deployment:
     # Scheduler update interval
   updateInterval: 5
 
-
-  # HA Configuration
-state.persistence:
-  enabled: false
-  intervalInMin: 1
-  revisionsToKeep: 3
-  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
-  # config:
-    # location: siddhi-app-persistence
-  config:
-    datasource: WSO2_ANALYTICS_DB
-    table: PERSISTENCE_TABLE
-
 cluster.config:
   enabled: true
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
-    datasource: WSO2_CLUSTER_DB
+    datasource: WSO2_CLUSTER_DB  # Datasource is not defined in yaml since test cases will internally create datasource
     heartbeatInterval: 1000
     heartbeatMaxAge: 2
     eventPollingInterval: 1000

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentTwo.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentTwo.yaml
@@ -197,9 +197,9 @@ state.persistence:
 
 cluster.config:
   enabled: true
-  group.id: testGroupOne
-  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
-  strategy.config:
-    heart.beat.interval: 100
-    heart.beat.max.age: 2
-    event.polling.interval: 500
+  groupId: testGroupOne
+  coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategyConfig:
+    heartbeatInterval: 1000
+    heartbeatMaxAge: 2
+    eventPollingInterval: 1000

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentTwo.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentTwo.yaml
@@ -182,19 +182,6 @@ wso2.artifact.deployment:
     # Scheduler update interval
   updateInterval: 5
 
-
-  # HA Configuration
-state.persistence:
-  enabled: false
-  intervalInMin: 1
-  revisionsToKeep: 3
-  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
-  # config:
-    # location: siddhi-app-persistence
-  config:
-    datasource: WSO2_ANALYTICS_DB
-    table: PERSISTENCE_TABLE
-
 cluster.config:
   enabled: true
   groupId: testGroupOne

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentTwo.yaml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/conf/deploymentTwo.yaml
@@ -1,0 +1,205 @@
+################################################################################
+#   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 0
+
+  # Configuration used for the databridge communication
+databridge.config:
+    # No of worker threads to consume events
+    # THIS IS A MANDATORY FIELD
+  workerThreads: 10
+    # Maximum amount of messages that can be queued internally in MB
+    # THIS IS A MANDATORY FIELD
+  maxEventBufferCapacity: 10000000
+    # Queue size; the maximum number of events that can be stored in the queue
+    # THIS IS A MANDATORY FIELD
+  eventBufferSize: 2000
+    # Keystore file path
+    # THIS IS A MANDATORY FIELD
+  keyStoreLocation : ${carbon.home}/resources/security/wso2carbon.jks
+    # Keystore password
+    # THIS IS A MANDATORY FIELD
+  keyStorePassword : wso2carbon
+    # Session Timeout value in mins
+    # THIS IS A MANDATORY FIELD
+  clientTimeoutMin: 30
+    # Data receiver configurations
+    # THIS IS A MANDATORY FIELD
+  dataReceivers:
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Thrift
+        # Data receiver properties
+      properties:
+        tcpPort: '7611'
+        sslPort: '7711'
+
+  -
+      # Data receiver configuration
+    dataReceiver:
+        # Data receiver type
+        # THIS IS A MANDATORY FIELD
+      type: Binary
+        # Data receiver properties
+      properties:
+        tcpPort: '9611'
+        sslPort: '9711'
+        tcpReceiverThreadPoolSize: '100'
+        sslReceiverThreadPoolSize: '100'
+        hostName: 0.0.0.0
+
+  # Configuration of the Data Agents - to publish events through databridge
+data.agent.config:
+    # Data agent configurations
+    # THIS IS A MANDATORY FIELD
+  agents:
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Thrift
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.thrift.ThriftDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+  -
+      # Data agent configuration
+    agentConfiguration:
+        # Data agent name
+        # THIS IS A MANDATORY FIELD
+      name: Binary
+        # Data endpoint class
+        # THIS IS A MANDATORY FIELD
+      dataEndpointClass: org.wso2.carbon.databridge.agent.endpoint.binary.BinaryDataEndpoint
+        # Data publisher strategy
+      publishingStrategy: async
+        # Trust store path
+      trustStorePath: '${carbon.home}/resources/security/client-truststore.jks'
+        # Trust store password
+      trustStorePassword: 'wso2carbon'
+        # Queue Size
+      queueSize: 32768
+        # Batch Size
+      batchSize: 200
+        # Core pool size
+      corePoolSize: 1
+        # Socket timeout in milliseconds
+      socketTimeoutMS: 30000
+        # Maximum pool size
+      maxPoolSize: 1
+        # Keep alive time in pool
+      keepAliveTimeInPool: 20
+        # Reconnection interval
+      reconnectionInterval: 30
+        # Max transport pool size
+      maxTransportPoolSize: 250
+        # Max idle connections
+      maxIdleConnections: 250
+        # Eviction time interval
+      evictionTimePeriod: 5500
+        # Min idle time in pool
+      minIdleTimeInPool: 5000
+        # Secure max transport pool size
+      secureMaxTransportPoolSize: 250
+        # Secure max idle connections
+      secureMaxIdleConnections: 250
+        # secure eviction time period
+      secureEvictionTimePeriod: 5500
+        # Secure min idle time in pool
+      secureMinIdleTimeInPool: 5000
+        # SSL enabled protocols
+      sslEnabledProtocols: TLSv1,TLSv1.1,TLSv1.2
+        # Ciphers
+      ciphers: SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+
+  # Deployment configuration parameters
+wso2.artifact.deployment:
+    # Scheduler update interval
+  updateInterval: 5
+
+
+  # HA Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 3
+  class: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
+  # config:
+    # location: siddhi-app-persistence
+  config:
+    datasource: WSO2_ANALYTICS_DB
+    table: PERSISTENCE_TABLE
+
+cluster.config:
+  enabled: true
+  group.id: testGroupOne
+  coordination.strategy.class: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
+  strategy.config:
+    heart.beat.interval: 100
+    heart.beat.max.age: 2
+    event.polling.interval: 500

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/testng.xml
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/test/resources/testng.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="rdbms" verbose="1" >
-    <test name="Coordination event flow rdbms" >
-        <packages>
-            <package name="org.wso2.carbon.cluster.coordinator.rdbms.test" />
-        </packages>
+    <test name="Coordination event flow rdbms" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.cluster.coordinator.rdbms.test.CoordinatorConfigDefaultValuesTestCase"/>
+            <class name="org.wso2.carbon.cluster.coordinator.rdbms.test.CoordinatorConfigDatasourceTestCase"/>
+            <class name="org.wso2.carbon.cluster.coordinator.rdbms.test.CoordinatorConfigGroupIdTestCase"/>
+            <class name="org.wso2.carbon.cluster.coordinator.rdbms.test.CoordinatorConfigEmptyValuesTestCase"/>
+            <class name="org.wso2.carbon.cluster.coordinator.rdbms.test.CoordinationEventFlowTestCase"/>
+        </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> When cluster.config configurations are not given the RDBMS service should not be registered to the bundle context and an exception should not be thrown.
> Add more test cases

## Goals
> Make a runtime run as normal even if the RDBMS Coordination Strategy jar is present but configurations are not given

## Approach
> If the cluster.config configurations is not present the exception thrown is removed

## Automation tests
 - Unit tests 
   > 71% line coverage

## Test environment
> JDK 8
> Ubuntu 16.04
 