### PR TITLE
Enable all task details to have the same timestamp and send 'member removed event' for all listeners

### DIFF
--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.commons/src/main/java/org/wso2/carbon/cluster/coordinator/commons/util/CommunicationBusContext.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.commons/src/main/java/org/wso2/carbon/cluster/coordinator/commons/util/CommunicationBusContext.java
@@ -60,7 +60,7 @@ public interface CommunicationBusContext {
      * @param age     maximum relative age with respect to current time in milliseconds
      * @return True if timed out, False otherwise
      */
-    boolean checkIfCoordinatorValid(String groupId, int age, long currentHeartbeatTime)
+    boolean checkIfCoordinatorValid(String groupId, String nodeId, int age, long currentHeartbeatTime)
             throws ClusterCoordinationException;
 
     /**

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.commons/src/main/java/org/wso2/carbon/cluster/coordinator/commons/util/CommunicationBusContext.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.commons/src/main/java/org/wso2/carbon/cluster/coordinator/commons/util/CommunicationBusContext.java
@@ -50,8 +50,7 @@ public interface CommunicationBusContext {
      * @param groupId local group ID
      * @param nodeId  local node ID
      */
-    boolean updateCoordinatorHeartbeat(String nodeId, String groupId, long currentHeartbeatTime)
-            throws ClusterCoordinationException;
+    boolean updateCoordinatorHeartbeat(String nodeId, String groupId) throws ClusterCoordinationException;
 
     /**
      * Check if the coordinator is timed out using the heart beat value
@@ -60,8 +59,7 @@ public interface CommunicationBusContext {
      * @param age     maximum relative age with respect to current time in milliseconds
      * @return True if timed out, False otherwise
      */
-    boolean checkIfCoordinatorValid(String groupId, int age, long currentHeartbeatTime)
-            throws ClusterCoordinationException;
+    boolean checkIfCoordinatorValid(String groupId, int age) throws ClusterCoordinationException;
 
     /**
      * Remove current Coordinator entry from database
@@ -69,7 +67,7 @@ public interface CommunicationBusContext {
      * @param groupId local group ID
      * @param age     maximum relative age with respect to current time in milliseconds
      */
-    void removeCoordinator(String groupId, int age, long currentHeartbeatTime) throws ClusterCoordinationException;
+    void removeCoordinator(String groupId, int age) throws ClusterCoordinationException;
 
     /**
      * Update Node heartbeat value to current time
@@ -77,8 +75,7 @@ public interface CommunicationBusContext {
      * @param groupId local group ID
      * @param nodeId  local node ID
      */
-    boolean updateNodeHeartbeat(String nodeId, String groupId, long currentHeartbeatTime)
-            throws ClusterCoordinationException;
+    boolean updateNodeHeartbeat(String nodeId, String groupId) throws ClusterCoordinationException;
 
     /**
      * Create Node heartbeat value to current time

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.commons/src/main/java/org/wso2/carbon/cluster/coordinator/commons/util/CommunicationBusContext.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.commons/src/main/java/org/wso2/carbon/cluster/coordinator/commons/util/CommunicationBusContext.java
@@ -50,7 +50,8 @@ public interface CommunicationBusContext {
      * @param groupId local group ID
      * @param nodeId  local node ID
      */
-    boolean updateCoordinatorHeartbeat(String nodeId, String groupId) throws ClusterCoordinationException;
+    boolean updateCoordinatorHeartbeat(String nodeId, String groupId, long currentHeartbeatTime)
+            throws ClusterCoordinationException;
 
     /**
      * Check if the coordinator is timed out using the heart beat value
@@ -59,7 +60,8 @@ public interface CommunicationBusContext {
      * @param age     maximum relative age with respect to current time in milliseconds
      * @return True if timed out, False otherwise
      */
-    boolean checkIfCoordinatorValid(String groupId, int age) throws ClusterCoordinationException;
+    boolean checkIfCoordinatorValid(String groupId, int age, long currentHeartbeatTime)
+            throws ClusterCoordinationException;
 
     /**
      * Remove current Coordinator entry from database
@@ -67,7 +69,7 @@ public interface CommunicationBusContext {
      * @param groupId local group ID
      * @param age     maximum relative age with respect to current time in milliseconds
      */
-    void removeCoordinator(String groupId, int age) throws ClusterCoordinationException;
+    void removeCoordinator(String groupId, int age, long currentHeartbeatTime) throws ClusterCoordinationException;
 
     /**
      * Update Node heartbeat value to current time
@@ -75,7 +77,8 @@ public interface CommunicationBusContext {
      * @param groupId local group ID
      * @param nodeId  local node ID
      */
-    boolean updateNodeHeartbeat(String nodeId, String groupId) throws ClusterCoordinationException;
+    boolean updateNodeHeartbeat(String nodeId, String groupId, long currentHeartbeatTime)
+            throws ClusterCoordinationException;
 
     /**
      * Create Node heartbeat value to current time

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
@@ -471,15 +471,14 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     }
 
     @Override
-    public boolean updateCoordinatorHeartbeat(String nodeId, String groupId, long currentHeartbeatTime)
-            throws ClusterCoordinationException {
+    public boolean updateCoordinatorHeartbeat(String nodeId, String groupId) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatementForCoordinatorUpdate = null;
         try {
             connection = getConnection();
             preparedStatementForCoordinatorUpdate = connection
                     .prepareStatement(queryManager.getQuery(QueryConstants.UPDATE_COORDINATOR_HEARTBEAT));
-            preparedStatementForCoordinatorUpdate.setLong(1, currentHeartbeatTime);
+            preparedStatementForCoordinatorUpdate.setLong(1, System.currentTimeMillis());
             preparedStatementForCoordinatorUpdate.setString(2, nodeId);
             preparedStatementForCoordinatorUpdate.setString(3, groupId);
             int updateCount = preparedStatementForCoordinatorUpdate.executeUpdate();
@@ -501,8 +500,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     }
 
     @Override
-    public boolean checkIfCoordinatorValid(String groupId, int heartbeatMaxAge, long currentHeartbeatTime)
-            throws ClusterCoordinationException {
+    public boolean checkIfCoordinatorValid(String groupId, int heartbeatMaxAge) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;
         ResultSet resultSet = null;
@@ -512,15 +510,16 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                     QueryConstants.GET_COORDINATOR_HEARTBEAT));
             preparedStatement.setString(1, groupId);
             resultSet = preparedStatement.executeQuery();
+            long currentTimeMillis = System.currentTimeMillis();
             boolean isCoordinator;
             if (resultSet.next()) {
                 long coordinatorHeartbeat = resultSet.getLong(1);
-                long heartbeatAge = currentHeartbeatTime - coordinatorHeartbeat;
+                long heartbeatAge = currentTimeMillis - coordinatorHeartbeat;
                 isCoordinator = heartbeatAge <= heartbeatMaxAge;
                 if (log.isDebugEnabled()) {
                     log.debug("isCoordinator: " + isCoordinator + ", heartbeatAge: " + heartbeatMaxAge
                             + ", coordinatorHeartBeat: " + coordinatorHeartbeat + ", currentTime: "
-                            + currentHeartbeatTime);
+                            + currentTimeMillis);
                 }
             } else {
                 if (log.isDebugEnabled()) {
@@ -540,13 +539,13 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     }
 
     @Override
-    public void removeCoordinator(String groupId, int heartbeatMaxAge, long currentHeartbeatTime)
-            throws ClusterCoordinationException {
+    public void removeCoordinator(String groupId, int heartbeatMaxAge) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;
         try {
             connection = getConnection();
-            long thresholdTimeLimit = currentHeartbeatTime - heartbeatMaxAge;
+            long currentTimeMillis = System.currentTimeMillis();
+            long thresholdTimeLimit = currentTimeMillis - heartbeatMaxAge;
             preparedStatement = connection.prepareStatement(queryManager.getQuery(QueryConstants.DELETE_COORDINATOR));
             preparedStatement.setString(1, groupId);
             preparedStatement.setLong(2, thresholdTimeLimit);
@@ -565,8 +564,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     }
 
     @Override
-    public boolean updateNodeHeartbeat(String nodeId, String groupId, long currentHeartbeatTime)
-            throws ClusterCoordinationException {
+    public boolean updateNodeHeartbeat(String nodeId, String groupId) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatementForNodeUpdate = null;
 
@@ -574,7 +572,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
             connection = getConnection();
             preparedStatementForNodeUpdate = connection.prepareStatement(queryManager.getQuery(
                     QueryConstants.UPDATE_NODE_HEARTBEAT));
-            preparedStatementForNodeUpdate.setLong(1, currentHeartbeatTime);
+            preparedStatementForNodeUpdate.setLong(1, System.currentTimeMillis());
             preparedStatementForNodeUpdate.setString(2, nodeId);
             preparedStatementForNodeUpdate.setString(3, groupId);
             int updateCount = preparedStatementForNodeUpdate.executeUpdate();
@@ -703,6 +701,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                                          String removedMemberId) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;
+        PreparedStatement clearMembershipEvents = null;
         ResultSet resultSet = null;
         NodeDetail nodeDetail = null;
         try {
@@ -739,31 +738,6 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                 nodeDetail = new NodeDetail(removedMemberId, groupId, false, 0, false,
                         propertiesMap);
             }
-            connection.commit();
-        } catch (SQLException e) {
-            String errMsg = RDBMSConstants.TASK_GET_ALL_QUEUES;
-            throw new ClusterCoordinationException("Error occurred while " + errMsg, e);
-        } catch (ClassNotFoundException e) {
-            throw new ClusterCoordinationException("Error retrieving the removed node data. ", e);
-        } finally {
-            close(resultSet, RDBMSConstants.TASK_GET_ALL_QUEUES);
-            close(preparedStatement, RDBMSConstants.TASK_GET_ALL_QUEUES);
-            close(connection, RDBMSConstants.TASK_GET_ALL_QUEUES);
-        }
-        if (log.isDebugEnabled()) {
-            log.debug(RDBMSConstants.TASK_GET_ALL_QUEUES + " of removed nodes in group "
-                    + StringUtil.removeCRLFCharacters(groupId) + " executed successfully");
-        }
-        return nodeDetail;
-    }
-
-    public void removeRecordsOfRemovedMemberDetails(String nodeId, String groupId,
-                                                     String removedMemberId) {
-        Connection connection = null;
-        PreparedStatement clearMembershipEvents = null;
-
-        try {
-            connection = getConnection();
             clearMembershipEvents = connection
                     .prepareStatement(queryManager.getQuery(QueryConstants.DELETE_REMOVED_MEMBER_DETAIL_FOR_NODE));
             clearMembershipEvents.setString(1, nodeId);
@@ -774,10 +748,19 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
         } catch (SQLException e) {
             String errMsg = RDBMSConstants.TASK_GET_ALL_QUEUES;
             throw new ClusterCoordinationException("Error occurred while " + errMsg, e);
+        } catch (ClassNotFoundException e) {
+            throw new ClusterCoordinationException("Error retrieving the removed node data. ", e);
         } finally {
+            close(resultSet, RDBMSConstants.TASK_GET_ALL_QUEUES);
+            close(preparedStatement, RDBMSConstants.TASK_GET_ALL_QUEUES);
             close(clearMembershipEvents, RDBMSConstants.TASK_GET_ALL_QUEUES);
             close(connection, RDBMSConstants.TASK_GET_ALL_QUEUES);
         }
+        if (log.isDebugEnabled()) {
+            log.debug(RDBMSConstants.TASK_GET_ALL_QUEUES + " of removed nodes in group "
+                    + StringUtil.removeCRLFCharacters(groupId) + " executed successfully");
+        }
+        return nodeDetail;
     }
 
     @Override

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
@@ -416,7 +416,6 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     public boolean createCoordinatorEntry(String nodeId, String groupId) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;
-
         try {
             connection = getConnection();
             preparedStatement = connection.prepareStatement(queryManager.getQuery(
@@ -501,8 +500,8 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
     }
 
     @Override
-    public boolean checkIfCoordinatorValid(String groupId, int heartbeatMaxAge, long currentHeartbeatTime)
-            throws ClusterCoordinationException {
+    public boolean checkIfCoordinatorValid(String groupId, String nodeId, int heartbeatMaxAge,
+                                           long currentHeartbeatTime) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;
         ResultSet resultSet = null;
@@ -512,23 +511,22 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                     QueryConstants.GET_COORDINATOR_HEARTBEAT));
             preparedStatement.setString(1, groupId);
             resultSet = preparedStatement.executeQuery();
-            boolean isCoordinator;
+            boolean isCoordinatorValid;
             if (resultSet.next()) {
                 long coordinatorHeartbeat = resultSet.getLong(1);
                 long heartbeatAge = currentHeartbeatTime - coordinatorHeartbeat;
-                isCoordinator = heartbeatAge <= heartbeatMaxAge;
-                if (log.isDebugEnabled()) {
-                    log.debug("isCoordinator: " + isCoordinator + ", heartbeatAge: " + heartbeatMaxAge
-                            + ", coordinatorHeartBeat: " + coordinatorHeartbeat + ", currentTime: "
-                            + currentHeartbeatTime);
+                isCoordinatorValid = heartbeatAge <= heartbeatMaxAge;
+                if (!isCoordinatorValid) {
+                    log.info("Coordinator is invalid, because there is no heartbeat for " + heartbeatAge
+                            + " millis when checked by nodeId: " + nodeId +
+                            ". The heartbeat should have happened in " + heartbeatMaxAge);
                 }
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("No coordinator present in database for group " + groupId);
-                }
-                isCoordinator = false;
+                log.info("No valid coordinator present in database for group " + groupId +
+                        " when checked by nodeId: " + nodeId);
+                isCoordinatorValid = false;
             }
-            return isCoordinator;
+            return isCoordinatorValid;
         } catch (SQLException e) {
             String errMsg = RDBMSConstants.TASK_CHECK_COORDINATOR_VALIDITY;
             throw new ClusterCoordinationException("Error occurred while " + errMsg, e);

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
@@ -701,6 +701,7 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                                          String removedMemberId) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;
+        PreparedStatement clearMembershipEvents = null;
         ResultSet resultSet = null;
         NodeDetail nodeDetail = null;
         try {
@@ -737,31 +738,6 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                 nodeDetail = new NodeDetail(removedMemberId, groupId, false, 0, false,
                         propertiesMap);
             }
-            connection.commit();
-        } catch (SQLException e) {
-            String errMsg = RDBMSConstants.TASK_GET_ALL_QUEUES;
-            throw new ClusterCoordinationException("Error occurred while " + errMsg, e);
-        } catch (ClassNotFoundException e) {
-            throw new ClusterCoordinationException("Error retrieving the removed node data. ", e);
-        } finally {
-            close(resultSet, RDBMSConstants.TASK_GET_ALL_QUEUES);
-            close(preparedStatement, RDBMSConstants.TASK_GET_ALL_QUEUES);
-            close(connection, RDBMSConstants.TASK_GET_ALL_QUEUES);
-        }
-        if (log.isDebugEnabled()) {
-            log.debug(RDBMSConstants.TASK_GET_ALL_QUEUES + " of removed nodes in group "
-                    + StringUtil.removeCRLFCharacters(groupId) + " executed successfully");
-        }
-        return nodeDetail;
-    }
-
-    public void removeRecordsOfRemovedMemberDetails(String nodeId, String groupId,
-                                                     String removedMemberId) {
-        Connection connection = null;
-        PreparedStatement clearMembershipEvents = null;
-
-        try {
-            connection = getConnection();
             clearMembershipEvents = connection
                     .prepareStatement(queryManager.getQuery(QueryConstants.DELETE_REMOVED_MEMBER_DETAIL_FOR_NODE));
             clearMembershipEvents.setString(1, nodeId);
@@ -772,10 +748,19 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
         } catch (SQLException e) {
             String errMsg = RDBMSConstants.TASK_GET_ALL_QUEUES;
             throw new ClusterCoordinationException("Error occurred while " + errMsg, e);
+        } catch (ClassNotFoundException e) {
+            throw new ClusterCoordinationException("Error retrieving the removed node data. ", e);
         } finally {
+            close(resultSet, RDBMSConstants.TASK_GET_ALL_QUEUES);
+            close(preparedStatement, RDBMSConstants.TASK_GET_ALL_QUEUES);
             close(clearMembershipEvents, RDBMSConstants.TASK_GET_ALL_QUEUES);
             close(connection, RDBMSConstants.TASK_GET_ALL_QUEUES);
         }
+        if (log.isDebugEnabled()) {
+            log.debug(RDBMSConstants.TASK_GET_ALL_QUEUES + " of removed nodes in group "
+                    + StringUtil.removeCRLFCharacters(groupId) + " executed successfully");
+        }
+        return nodeDetail;
     }
 
     @Override

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCommunicationBusContextImpl.java
@@ -701,7 +701,6 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                                          String removedMemberId) throws ClusterCoordinationException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;
-        PreparedStatement clearMembershipEvents = null;
         ResultSet resultSet = null;
         NodeDetail nodeDetail = null;
         try {
@@ -738,6 +737,31 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
                 nodeDetail = new NodeDetail(removedMemberId, groupId, false, 0, false,
                         propertiesMap);
             }
+            connection.commit();
+        } catch (SQLException e) {
+            String errMsg = RDBMSConstants.TASK_GET_ALL_QUEUES;
+            throw new ClusterCoordinationException("Error occurred while " + errMsg, e);
+        } catch (ClassNotFoundException e) {
+            throw new ClusterCoordinationException("Error retrieving the removed node data. ", e);
+        } finally {
+            close(resultSet, RDBMSConstants.TASK_GET_ALL_QUEUES);
+            close(preparedStatement, RDBMSConstants.TASK_GET_ALL_QUEUES);
+            close(connection, RDBMSConstants.TASK_GET_ALL_QUEUES);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug(RDBMSConstants.TASK_GET_ALL_QUEUES + " of removed nodes in group "
+                    + StringUtil.removeCRLFCharacters(groupId) + " executed successfully");
+        }
+        return nodeDetail;
+    }
+
+    public void removeRecordsOfRemovedMemberDetails(String nodeId, String groupId,
+                                                     String removedMemberId) {
+        Connection connection = null;
+        PreparedStatement clearMembershipEvents = null;
+
+        try {
+            connection = getConnection();
             clearMembershipEvents = connection
                     .prepareStatement(queryManager.getQuery(QueryConstants.DELETE_REMOVED_MEMBER_DETAIL_FOR_NODE));
             clearMembershipEvents.setString(1, nodeId);
@@ -748,19 +772,10 @@ public class RDBMSCommunicationBusContextImpl implements CommunicationBusContext
         } catch (SQLException e) {
             String errMsg = RDBMSConstants.TASK_GET_ALL_QUEUES;
             throw new ClusterCoordinationException("Error occurred while " + errMsg, e);
-        } catch (ClassNotFoundException e) {
-            throw new ClusterCoordinationException("Error retrieving the removed node data. ", e);
         } finally {
-            close(resultSet, RDBMSConstants.TASK_GET_ALL_QUEUES);
-            close(preparedStatement, RDBMSConstants.TASK_GET_ALL_QUEUES);
             close(clearMembershipEvents, RDBMSConstants.TASK_GET_ALL_QUEUES);
             close(connection, RDBMSConstants.TASK_GET_ALL_QUEUES);
         }
-        if (log.isDebugEnabled()) {
-            log.debug(RDBMSConstants.TASK_GET_ALL_QUEUES + " of removed nodes in group "
-                    + StringUtil.removeCRLFCharacters(groupId) + " executed successfully");
-        }
-        return nodeDetail;
     }
 
     @Override

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCoordinationStrategy.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCoordinationStrategy.java
@@ -35,10 +35,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 
 /**
@@ -59,12 +59,12 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
     /**
      * After this much of time the node is assumed to have left the cluster.
      */
-    private final int heartbeatMaxRetry;
+    private final int heartbeatMaxRetryInterval;
 
     /**
      * Thread executor used to run the coordination algorithm.
      */
-    private final ScheduledExecutorService threadExecutor;
+    private final ExecutorService threadExecutor;
 
     /**
      * Used to send and receive cluster notifications.
@@ -121,7 +121,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                 this.heartBeatInterval = strategyConfiguration.getHeartbeatInterval();
                 // Maximum age of a heartbeat. After this much of time, the heartbeat is considered invalid and node is
                 // considered to have left the cluster.
-                this.heartbeatMaxRetry = heartBeatInterval * strategyConfiguration.getHeartbeatMaxRetry();
+                this.heartbeatMaxRetryInterval = heartBeatInterval * strategyConfiguration.getHeartbeatMaxRetry();
                 this.localGroupId = clusterConfiguration.getGroupId();
             } else {
                 throw new ClusterCoordinationException("Strategy Configurations not found in" +
@@ -139,7 +139,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         }
         ThreadFactory namedThreadFactory = new ThreadFactoryBuilder()
                 .setNameFormat("RDBMSCoordinationStrategy-%d").build();
-        this.threadExecutor = Executors.newSingleThreadScheduledExecutor(namedThreadFactory);
+        this.threadExecutor = Executors.newSingleThreadExecutor(namedThreadFactory);
         try {
             ConfigProvider configProvider = RDBMSCoordinationServiceHolder.getConfigProvider();
             if (configProvider != null) {
@@ -154,8 +154,8 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                     " the id property.");
         }
         this.communicationBusContext = communicationBusContext;
-        this.rdbmsMemberEventProcessor = new RDBMSMemberEventProcessor(localNodeId, localGroupId, heartbeatMaxRetry,
-                communicationBusContext);
+        this.rdbmsMemberEventProcessor = new RDBMSMemberEventProcessor(localNodeId, localGroupId,
+                heartbeatMaxRetryInterval, communicationBusContext);
     }
 
     @Override
@@ -164,7 +164,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         List<NodeDetail> liveNodeDetails = new ArrayList<>();
         for (NodeDetail nodeDetail : allNodeDetails) {
             long heartbeatAge = System.currentTimeMillis() - nodeDetail.getLastHeartbeat();
-            if (heartbeatAge < heartbeatMaxRetry) {
+            if (heartbeatAge < heartbeatMaxRetryInterval) {
                 liveNodeDetails.add(nodeDetail);
             }
         }
@@ -210,17 +210,53 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
             long lastHeartBeat = nodeDetail.getLastHeartbeat();
             long currentTimeMillis = System.currentTimeMillis();
             long heartbeatAge = currentTimeMillis - lastHeartBeat;
-            isNodeExist = (heartbeatAge < heartbeatMaxRetry);
+            isNodeExist = (heartbeatAge < heartbeatMaxRetryInterval);
         }
 
         if (!isNodeExist) {
-            CoordinatorElectionTask coordinatorElectionTask = new CoordinatorElectionTask(localNodeId,
-                    localGroupId, propertiesMap);
-            this.threadExecutor.scheduleAtFixedRate(coordinatorElectionTask, 0, heartBeatInterval,
-                    TimeUnit.MILLISECONDS);
+            Future heartbeatExecutionResult = this.threadExecutor.submit(new HeartBeatExecutionTask(propertiesMap));
+            if (heartbeatExecutionResult.isCancelled()) {
+                log.warn("Heart beat execution task has been cancelled.");
+            }
         } else {
             throw new ClusterCoordinationException("Node with ID " + localNodeId + " in group " + localGroupId +
                     " already exists.");
+        }
+    }
+
+    /**
+     * This class will schedule and execute coordination tasks
+     */
+    public class HeartBeatExecutionTask implements Runnable {
+        private CoordinatorElectionTask coordinatorElectionTask;
+        private long currentHeartbeatTime = System.currentTimeMillis();
+        public HeartBeatExecutionTask(Map<String, Object> propertiesMap) {
+            coordinatorElectionTask = new CoordinatorElectionTask(localNodeId, localGroupId, propertiesMap);
+        }
+        @Override
+        public void run() {
+            while (true) {
+                try {
+                    coordinatorElectionTask.runCoordinationElectionTask(currentHeartbeatTime);
+                    long taskEnddedTime = System.currentTimeMillis();
+                    long nextHeartbeatTime = currentHeartbeatTime + heartBeatInterval;
+                    if (taskEnddedTime - nextHeartbeatTime >= 0) {
+                        log.info(currentHeartbeatTime + " heartBeatInterval is " + heartBeatInterval +
+                                ". But current Heartbeat is happening after " +
+                                (taskEnddedTime - currentHeartbeatTime) + " millis");
+
+                    } else {
+                        try {
+                            Thread.sleep((nextHeartbeatTime - taskEnddedTime));
+                        } catch (InterruptedException e) {
+                            log.error("Exception on HeartBeatExecutionTask thread sleep.");
+                        }
+                    }
+                    currentHeartbeatTime = System.currentTimeMillis();
+                } catch (Throwable t) {
+                    throw new ClusterCoordinationException("Error occurred while performing coordinator tasks.", t);
+                }
+            }
         }
     }
 
@@ -248,7 +284,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
     /**
      * For each member, this class will run in a separate thread.
      */
-    private class CoordinatorElectionTask implements Runnable {
+    private class CoordinatorElectionTask {
 
         /**
          * Current state of the node.
@@ -283,25 +319,50 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
             this.currentNodeState = NodeState.MEMBER;
         }
 
-        @Override
-        public void run() {
+        public void runCoordinationElectionTask (long currentHeartbeatTime) {
             try {
                 if (log.isDebugEnabled()) {
                     log.debug("Current node state: " + currentNodeState);
                 }
+                long timeTakenForMemberTasks[] = new long[4];
+                long timeTakenForCoordinatorTasks[] = new long[5];
                 switch (currentNodeState) {
                     case MEMBER:
-                        performMemberTask();
+                        performMemberTask(currentHeartbeatTime, timeTakenForMemberTasks);
                         break;
                     case COORDINATOR:
-                        performCoordinatorTask();
+                        performCoordinatorTask(currentHeartbeatTime, timeTakenForCoordinatorTasks);
                         break;
+                }
+                long clusterTaskEndingTime = System.currentTimeMillis();
+                if (log.isDebugEnabled() && clusterTaskEndingTime - currentHeartbeatTime > 1000) {
+                    log.debug(clusterTaskEndingTime + " Cluster task took " +
+                            (clusterTaskEndingTime - currentHeartbeatTime) + " millis to complete on " +
+                            currentNodeState + " node.");
+                    switch (currentNodeState) {
+                        case MEMBER:
+                            log.debug(clusterTaskEndingTime +
+                                    "\nupdateNodeHeartBeat(): " + timeTakenForMemberTasks[0] +
+                                    "\ncheckIfCoordinatorValid(): " + timeTakenForMemberTasks[1] +
+                                    "\nremoveCoordinator() if coordinator invalid: " + timeTakenForMemberTasks[2] +
+                                    "\nperformElectionTask() if coordinator invalid: " + timeTakenForMemberTasks[3]);
+                            break;
+                        case COORDINATOR:
+                            log.debug(clusterTaskEndingTime +
+                                    "\nupdateCoordinatorHeartbeat(): " + timeTakenForCoordinatorTasks[0] +
+                                    "\nupdateNodeHeartBeat() if still coordinator: " + timeTakenForCoordinatorTasks[1] +
+                                    "\ngetAllNodeData() if still coordinator: " + timeTakenForCoordinatorTasks[2] +
+                                    "\nfindAddedRemovedMembers() if still coordinator: " +
+                                        timeTakenForCoordinatorTasks[3] +
+                                    "\nperformElectionTask() if NOT still coordinator: " +
+                                        timeTakenForCoordinatorTasks[4]);
+                            break;
+                    }
                 }
                 // We are catching throwable to avoid subsequent executions getting suppressed
             } catch (Throwable e) {
                 log.error("Error detected while running coordination algorithm. Node became a "
                         + NodeState.MEMBER + " node in group " + localGroupId, e);
-
                 currentNodeState = NodeState.MEMBER;
             }
         }
@@ -312,16 +373,32 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          * @throws ClusterCoordinationException
          * @throws InterruptedException
          */
-        private void performMemberTask() throws ClusterCoordinationException, InterruptedException {
-            updateNodeHeartBeat();
-            boolean coordinatorValid = communicationBusContext.checkIfCoordinatorValid(localGroupId, heartbeatMaxRetry);
+        private void performMemberTask(long currentHeartbeatTime, long[] timeTakenForMemberTasks)
+                throws ClusterCoordinationException, InterruptedException {
+            long taskStartTime = System.currentTimeMillis();
+            long taskEndTime;
+            updateNodeHeartBeat(currentHeartbeatTime);
+            taskEndTime = System.currentTimeMillis();
+            timeTakenForMemberTasks[0] = taskEndTime - taskStartTime;
+            taskStartTime = taskEndTime;
+            boolean coordinatorValid = communicationBusContext.checkIfCoordinatorValid(localGroupId,
+                    heartbeatMaxRetryInterval, currentHeartbeatTime);
+            taskEndTime = System.currentTimeMillis();
+            timeTakenForMemberTasks[1] = taskEndTime - taskStartTime;
             if (!coordinatorValid) {
                 if (log.isDebugEnabled()) {
                     log.debug("Node ID :" + localNodeId
                             + " Going for election since the Coordinator is invalid for group ID: " + localGroupId);
                 }
-                communicationBusContext.removeCoordinator(localGroupId, heartbeatMaxRetry);
-                performElectionTask();
+                taskStartTime = taskEndTime;
+                communicationBusContext.removeCoordinator(localGroupId, heartbeatMaxRetryInterval,
+                        currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForMemberTasks[2] = taskEndTime - taskStartTime;
+                taskStartTime = taskEndTime;
+                performElectionTask(currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForMemberTasks[3] = taskEndTime - taskStartTime;
             }
         }
 
@@ -331,8 +408,9 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          *
          * @throws ClusterCoordinationException
          */
-        private void updateNodeHeartBeat() throws ClusterCoordinationException {
-            boolean heartbeatEntryExists = communicationBusContext.updateNodeHeartbeat(localNodeId, localGroupId);
+        private void updateNodeHeartBeat(long currentHeartbeatTime) throws ClusterCoordinationException {
+            boolean heartbeatEntryExists = communicationBusContext.updateNodeHeartbeat(localNodeId, localGroupId,
+                    currentHeartbeatTime);
             if (!heartbeatEntryExists) {
                 communicationBusContext.createNodeHeartbeatEntry(localNodeId, localGroupId, localPropertiesMap);
             }
@@ -344,21 +422,37 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          * @throws ClusterCoordinationException
          * @throws InterruptedException
          */
-        private void performCoordinatorTask()
+        private void performCoordinatorTask(long currentHeartbeatTime, long[] timeTakenForCoordinatorTasks)
                 throws ClusterCoordinationException, InterruptedException {
             // Try to update the coordinator heartbeat
-            boolean stillCoordinator = communicationBusContext.updateCoordinatorHeartbeat(localNodeId, localGroupId);
+            long taskStartTime = System.currentTimeMillis();
+            long taskEndTime;
+            boolean stillCoordinator = communicationBusContext.
+                    updateCoordinatorHeartbeat(localNodeId, localGroupId, currentHeartbeatTime);
+            taskEndTime = System.currentTimeMillis();
+            timeTakenForCoordinatorTasks[0] = taskEndTime - taskStartTime;
+            taskStartTime = taskEndTime;
             if (stillCoordinator) {
-                updateNodeHeartBeat();
-                long currentTimeMillis = System.currentTimeMillis();
+                updateNodeHeartBeat(currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForCoordinatorTasks[1] = taskEndTime - taskStartTime;
+                taskStartTime = taskEndTime;
                 List<NodeDetail> allNodeInformation = communicationBusContext.getAllNodeData(localGroupId);
-                findAddedRemovedMembers(allNodeInformation, currentTimeMillis);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForCoordinatorTasks[2] = taskEndTime - taskStartTime;
+                taskStartTime = taskEndTime;
+                findAddedRemovedMembers(allNodeInformation, currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForCoordinatorTasks[3] = taskEndTime - taskStartTime;
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Going for election since Coordinator state is lost in group " + localGroupId);
                 }
-                performElectionTask();
+                performElectionTask(currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForCoordinatorTasks[4] = taskEndTime - taskStartTime;
             }
+
         }
 
         /**
@@ -375,7 +469,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
             for (NodeDetail nodeDetail : allNodeInformation) {
                 long heartbeatAge = currentTimeMillis - nodeDetail.getLastHeartbeat();
                 String nodeId = nodeDetail.getNodeId();
-                if (heartbeatAge >= heartbeatMaxRetry) {
+                if (heartbeatAge >= heartbeatMaxRetryInterval) {
                     removedNodes.add(nodeId);
                     allActiveNodeIds.remove(nodeId);
                     removedNodeDetails.add(nodeDetail);
@@ -443,9 +537,9 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          *
          * @throws InterruptedException
          */
-        private void performElectionTask() throws InterruptedException {
+        private void performElectionTask(long currentHeartbeatTime) throws InterruptedException {
             try {
-                this.currentNodeState = tryToElectSelfAsCoordinator();
+                this.currentNodeState = tryToElectSelfAsCoordinator(currentHeartbeatTime);
             } catch (ClusterCoordinationException e) {
                 if (log.isDebugEnabled()) {
                     log.debug("Current node became a " + NodeState.MEMBER + " node in group "
@@ -462,7 +556,8 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          * @throws ClusterCoordinationException
          * @throws InterruptedException
          */
-        private NodeState tryToElectSelfAsCoordinator() throws ClusterCoordinationException, InterruptedException {
+        private NodeState tryToElectSelfAsCoordinator(long currentHeartbeatTime)
+                throws ClusterCoordinationException, InterruptedException {
             NodeState nextState;
             boolean electedAsCoordinator = communicationBusContext.createCoordinatorEntry(localNodeId, localGroupId);
             if (electedAsCoordinator) {
@@ -470,7 +565,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                     log.debug("Elected current node as the coordinator in group " + localGroupId);
                 }
                 List<NodeDetail> allNodeInformation = communicationBusContext.getAllNodeData(localGroupId);
-                findAddedRemovedMembers(allNodeInformation, System.currentTimeMillis());
+                findAddedRemovedMembers(allNodeInformation, currentHeartbeatTime);
                 nextState = NodeState.COORDINATOR;
                 // notify nodes about coordinator change
                 List<String> nodeIdentifiers = new ArrayList<>();

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCoordinationStrategy.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCoordinationStrategy.java
@@ -131,8 +131,13 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                 this.heartBeatInterval = strategyConfiguration.getHeartbeatInterval();
                 // Maximum age of a heartbeat. After this much of time, the heartbeat is considered invalid and node is
                 // considered to have left the cluster.
-                this.heartbeatMaxRetryInterval = heartBeatInterval * strategyConfiguration.getHeartbeatMaxRetry();
                 heartbeatMaxRetry = strategyConfiguration.getHeartbeatMaxRetry();
+                if (heartbeatMaxRetry < 1) {
+                    throw new ClusterCoordinationException("heartbeatMaxRetry configuration should be larger than 0 in" +
+                            " deployment.yaml, please check " + CoordinationPropertyNames.STRATEGY_CONFIG_NS + " under "
+                            + CoordinationPropertyNames.CLUSTER_CONFIG_NS + " namespace configurations");
+                }
+                this.heartbeatMaxRetryInterval = heartBeatInterval * heartbeatMaxRetry;
                 this.heartbeatWarningMargin = heartbeatMaxRetryInterval * 0.75;
                 this.localGroupId = clusterConfiguration.getGroupId();
             } else {

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCoordinationStrategy.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSCoordinationStrategy.java
@@ -35,10 +35,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 
 /**
@@ -59,12 +58,12 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
     /**
      * After this much of time the node is assumed to have left the cluster.
      */
-    private final int heartbeatMaxRetry;
+    private final int heartbeatMaxRetryInterval;
 
     /**
      * Thread executor used to run the coordination algorithm.
      */
-    private final ScheduledExecutorService threadExecutor;
+    private final ExecutorService threadExecutor;
 
     /**
      * Used to send and receive cluster notifications.
@@ -97,6 +96,8 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         COORDINATOR, MEMBER
     }
 
+    private boolean isCoordinatorTasksRunning;
+
     /**
      * Instantiate RDBMSCoordinationStrategy with Datasource configuration read from deployment.yaml
      */
@@ -121,7 +122,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                 this.heartBeatInterval = strategyConfiguration.getHeartbeatInterval();
                 // Maximum age of a heartbeat. After this much of time, the heartbeat is considered invalid and node is
                 // considered to have left the cluster.
-                this.heartbeatMaxRetry = heartBeatInterval * strategyConfiguration.getHeartbeatMaxRetry();
+                this.heartbeatMaxRetryInterval = heartBeatInterval * strategyConfiguration.getHeartbeatMaxRetry();
                 this.localGroupId = clusterConfiguration.getGroupId();
             } else {
                 throw new ClusterCoordinationException("Strategy Configurations not found in" +
@@ -139,7 +140,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         }
         ThreadFactory namedThreadFactory = new ThreadFactoryBuilder()
                 .setNameFormat("RDBMSCoordinationStrategy-%d").build();
-        this.threadExecutor = Executors.newSingleThreadScheduledExecutor(namedThreadFactory);
+        this.threadExecutor = Executors.newSingleThreadExecutor(namedThreadFactory);
         try {
             ConfigProvider configProvider = RDBMSCoordinationServiceHolder.getConfigProvider();
             if (configProvider != null) {
@@ -154,8 +155,8 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                     " the id property.");
         }
         this.communicationBusContext = communicationBusContext;
-        this.rdbmsMemberEventProcessor = new RDBMSMemberEventProcessor(localNodeId, localGroupId, heartbeatMaxRetry,
-                communicationBusContext);
+        this.rdbmsMemberEventProcessor = new RDBMSMemberEventProcessor(localNodeId, localGroupId,
+                heartbeatMaxRetryInterval, communicationBusContext);
     }
 
     @Override
@@ -164,7 +165,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
         List<NodeDetail> liveNodeDetails = new ArrayList<>();
         for (NodeDetail nodeDetail : allNodeDetails) {
             long heartbeatAge = System.currentTimeMillis() - nodeDetail.getLastHeartbeat();
-            if (heartbeatAge < heartbeatMaxRetry) {
+            if (heartbeatAge < heartbeatMaxRetryInterval) {
                 liveNodeDetails.add(nodeDetail);
             }
         }
@@ -210,17 +211,50 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
             long lastHeartBeat = nodeDetail.getLastHeartbeat();
             long currentTimeMillis = System.currentTimeMillis();
             long heartbeatAge = currentTimeMillis - lastHeartBeat;
-            isNodeExist = (heartbeatAge < heartbeatMaxRetry);
+            isNodeExist = (heartbeatAge < heartbeatMaxRetryInterval);
         }
 
         if (!isNodeExist) {
-            CoordinatorElectionTask coordinatorElectionTask = new CoordinatorElectionTask(localNodeId,
-                    localGroupId, propertiesMap);
-            this.threadExecutor.scheduleAtFixedRate(coordinatorElectionTask, 0, heartBeatInterval,
-                    TimeUnit.MILLISECONDS);
+            isCoordinatorTasksRunning = true;
+            this.threadExecutor.execute(new HeartBeatExecutionTask(propertiesMap));
         } else {
             throw new ClusterCoordinationException("Node with ID " + localNodeId + " in group " + localGroupId +
                     " already exists.");
+        }
+    }
+
+    /**
+     * This class will schedule and execute coordination tasks
+     */
+    public class HeartBeatExecutionTask implements Runnable {
+        private CoordinatorElectionTask coordinatorElectionTask;
+        private long currentHeartbeatTime = System.currentTimeMillis();
+        public HeartBeatExecutionTask(Map<String, Object> propertiesMap) {
+            coordinatorElectionTask = new CoordinatorElectionTask(localNodeId, localGroupId, propertiesMap);
+        }
+        @Override
+        public void run() {
+            while (isCoordinatorTasksRunning) {
+                try {
+                    coordinatorElectionTask.runCoordinationElectionTask(currentHeartbeatTime);
+                    long taskEndedTime = System.currentTimeMillis();
+                    long nextHeartbeatTime = currentHeartbeatTime + heartBeatInterval;
+                    if (taskEndedTime - nextHeartbeatTime >= 0) {
+                        log.warn(currentHeartbeatTime + " heartBeatInterval is " + heartBeatInterval +
+                                ". But current Heartbeat is happening after " +
+                                (taskEndedTime - currentHeartbeatTime) + " millis");
+                    } else {
+                        try {
+                            Thread.sleep((nextHeartbeatTime - taskEndedTime));
+                        } catch (InterruptedException e) {
+                            log.error("Exception on HeartBeatExecutionTask thread sleep.");
+                        }
+                    }
+                    currentHeartbeatTime = System.currentTimeMillis();
+                } catch (Throwable t) {
+                    throw new ClusterCoordinationException("Error occurred while performing coordinator tasks.", t);
+                }
+            }
         }
     }
 
@@ -237,7 +271,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
     }
 
     public void stop() {
-        this.threadExecutor.shutdown();
+        isCoordinatorTasksRunning = false;
         this.rdbmsMemberEventProcessor.stop();
     }
 
@@ -248,7 +282,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
     /**
      * For each member, this class will run in a separate thread.
      */
-    private class CoordinatorElectionTask implements Runnable {
+    private class CoordinatorElectionTask {
 
         /**
          * Current state of the node.
@@ -283,25 +317,50 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
             this.currentNodeState = NodeState.MEMBER;
         }
 
-        @Override
-        public void run() {
+        public void runCoordinationElectionTask (long currentHeartbeatTime) {
             try {
                 if (log.isDebugEnabled()) {
                     log.debug("Current node state: " + currentNodeState);
                 }
+                long timeTakenForMemberTasks[] = new long[4];
+                long timeTakenForCoordinatorTasks[] = new long[5];
                 switch (currentNodeState) {
                     case MEMBER:
-                        performMemberTask();
+                        performMemberTask(currentHeartbeatTime, timeTakenForMemberTasks);
                         break;
                     case COORDINATOR:
-                        performCoordinatorTask();
+                        performCoordinatorTask(currentHeartbeatTime, timeTakenForCoordinatorTasks);
                         break;
+                }
+                long clusterTaskEndingTime = System.currentTimeMillis();
+                if (log.isDebugEnabled() && clusterTaskEndingTime - currentHeartbeatTime > 1000) {
+                    log.debug(clusterTaskEndingTime + " Cluster task took " +
+                            (clusterTaskEndingTime - currentHeartbeatTime) + " millis to complete on " +
+                            currentNodeState + " node.");
+                    switch (currentNodeState) {
+                        case MEMBER:
+                            log.debug(clusterTaskEndingTime +
+                                    "\nupdateNodeHeartBeat(): " + timeTakenForMemberTasks[0] +
+                                    "\ncheckIfCoordinatorValid(): " + timeTakenForMemberTasks[1] +
+                                    "\nremoveCoordinator() if coordinator invalid: " + timeTakenForMemberTasks[2] +
+                                    "\nperformElectionTask() if coordinator invalid: " + timeTakenForMemberTasks[3]);
+                            break;
+                        case COORDINATOR:
+                            log.debug(clusterTaskEndingTime +
+                                    "\nupdateCoordinatorHeartbeat(): " + timeTakenForCoordinatorTasks[0] +
+                                    "\nupdateNodeHeartBeat() if still coordinator: " + timeTakenForCoordinatorTasks[1] +
+                                    "\ngetAllNodeData() if still coordinator: " + timeTakenForCoordinatorTasks[2] +
+                                    "\nfindAddedRemovedMembers() if still coordinator: " +
+                                        timeTakenForCoordinatorTasks[3] +
+                                    "\nperformElectionTask() if NOT still coordinator: " +
+                                        timeTakenForCoordinatorTasks[4]);
+                            break;
+                    }
                 }
                 // We are catching throwable to avoid subsequent executions getting suppressed
             } catch (Throwable e) {
                 log.error("Error detected while running coordination algorithm. Node became a "
                         + NodeState.MEMBER + " node in group " + localGroupId, e);
-
                 currentNodeState = NodeState.MEMBER;
             }
         }
@@ -312,16 +371,32 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          * @throws ClusterCoordinationException
          * @throws InterruptedException
          */
-        private void performMemberTask() throws ClusterCoordinationException, InterruptedException {
-            updateNodeHeartBeat();
-            boolean coordinatorValid = communicationBusContext.checkIfCoordinatorValid(localGroupId, heartbeatMaxRetry);
+        private void performMemberTask(long currentHeartbeatTime, long[] timeTakenForMemberTasks)
+                throws ClusterCoordinationException, InterruptedException {
+            long taskStartTime = System.currentTimeMillis();
+            long taskEndTime;
+            updateNodeHeartBeat(currentHeartbeatTime);
+            taskEndTime = System.currentTimeMillis();
+            timeTakenForMemberTasks[0] = taskEndTime - taskStartTime;
+            taskStartTime = taskEndTime;
+            boolean coordinatorValid = communicationBusContext.checkIfCoordinatorValid(localGroupId,
+                    heartbeatMaxRetryInterval, currentHeartbeatTime);
+            taskEndTime = System.currentTimeMillis();
+            timeTakenForMemberTasks[1] = taskEndTime - taskStartTime;
             if (!coordinatorValid) {
                 if (log.isDebugEnabled()) {
                     log.debug("Node ID :" + localNodeId
                             + " Going for election since the Coordinator is invalid for group ID: " + localGroupId);
                 }
-                communicationBusContext.removeCoordinator(localGroupId, heartbeatMaxRetry);
-                performElectionTask();
+                taskStartTime = taskEndTime;
+                communicationBusContext.removeCoordinator(localGroupId, heartbeatMaxRetryInterval,
+                        currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForMemberTasks[2] = taskEndTime - taskStartTime;
+                taskStartTime = taskEndTime;
+                performElectionTask(currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForMemberTasks[3] = taskEndTime - taskStartTime;
             }
         }
 
@@ -331,8 +406,9 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          *
          * @throws ClusterCoordinationException
          */
-        private void updateNodeHeartBeat() throws ClusterCoordinationException {
-            boolean heartbeatEntryExists = communicationBusContext.updateNodeHeartbeat(localNodeId, localGroupId);
+        private void updateNodeHeartBeat(long currentHeartbeatTime) throws ClusterCoordinationException {
+            boolean heartbeatEntryExists = communicationBusContext.updateNodeHeartbeat(localNodeId, localGroupId,
+                    currentHeartbeatTime);
             if (!heartbeatEntryExists) {
                 communicationBusContext.createNodeHeartbeatEntry(localNodeId, localGroupId, localPropertiesMap);
             }
@@ -344,20 +420,35 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          * @throws ClusterCoordinationException
          * @throws InterruptedException
          */
-        private void performCoordinatorTask()
+        private void performCoordinatorTask(long currentHeartbeatTime, long[] timeTakenForCoordinatorTasks)
                 throws ClusterCoordinationException, InterruptedException {
             // Try to update the coordinator heartbeat
-            boolean stillCoordinator = communicationBusContext.updateCoordinatorHeartbeat(localNodeId, localGroupId);
+            long taskStartTime = System.currentTimeMillis();
+            long taskEndTime;
+            boolean stillCoordinator = communicationBusContext.
+                    updateCoordinatorHeartbeat(localNodeId, localGroupId, currentHeartbeatTime);
+            taskEndTime = System.currentTimeMillis();
+            timeTakenForCoordinatorTasks[0] = taskEndTime - taskStartTime;
+            taskStartTime = taskEndTime;
             if (stillCoordinator) {
-                updateNodeHeartBeat();
-                long currentTimeMillis = System.currentTimeMillis();
+                updateNodeHeartBeat(currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForCoordinatorTasks[1] = taskEndTime - taskStartTime;
+                taskStartTime = taskEndTime;
                 List<NodeDetail> allNodeInformation = communicationBusContext.getAllNodeData(localGroupId);
-                findAddedRemovedMembers(allNodeInformation, currentTimeMillis);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForCoordinatorTasks[2] = taskEndTime - taskStartTime;
+                taskStartTime = taskEndTime;
+                findAddedRemovedMembers(allNodeInformation, currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForCoordinatorTasks[3] = taskEndTime - taskStartTime;
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Going for election since Coordinator state is lost in group " + localGroupId);
                 }
-                performElectionTask();
+                performElectionTask(currentHeartbeatTime);
+                taskEndTime = System.currentTimeMillis();
+                timeTakenForCoordinatorTasks[4] = taskEndTime - taskStartTime;
             }
         }
 
@@ -375,7 +466,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
             for (NodeDetail nodeDetail : allNodeInformation) {
                 long heartbeatAge = currentTimeMillis - nodeDetail.getLastHeartbeat();
                 String nodeId = nodeDetail.getNodeId();
-                if (heartbeatAge >= heartbeatMaxRetry) {
+                if (heartbeatAge >= heartbeatMaxRetryInterval) {
                     removedNodes.add(nodeId);
                     allActiveNodeIds.remove(nodeId);
                     removedNodeDetails.add(nodeDetail);
@@ -443,9 +534,9 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          *
          * @throws InterruptedException
          */
-        private void performElectionTask() throws InterruptedException {
+        private void performElectionTask(long currentHeartbeatTime) throws InterruptedException {
             try {
-                this.currentNodeState = tryToElectSelfAsCoordinator();
+                this.currentNodeState = tryToElectSelfAsCoordinator(currentHeartbeatTime);
             } catch (ClusterCoordinationException e) {
                 if (log.isDebugEnabled()) {
                     log.debug("Current node became a " + NodeState.MEMBER + " node in group "
@@ -462,7 +553,8 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
          * @throws ClusterCoordinationException
          * @throws InterruptedException
          */
-        private NodeState tryToElectSelfAsCoordinator() throws ClusterCoordinationException, InterruptedException {
+        private NodeState tryToElectSelfAsCoordinator(long currentHeartbeatTime)
+                throws ClusterCoordinationException, InterruptedException {
             NodeState nextState;
             boolean electedAsCoordinator = communicationBusContext.createCoordinatorEntry(localNodeId, localGroupId);
             if (electedAsCoordinator) {
@@ -470,7 +562,7 @@ public class RDBMSCoordinationStrategy implements CoordinationStrategy {
                     log.debug("Elected current node as the coordinator in group " + localGroupId);
                 }
                 List<NodeDetail> allNodeInformation = communicationBusContext.getAllNodeData(localGroupId);
-                findAddedRemovedMembers(allNodeInformation, System.currentTimeMillis());
+                findAddedRemovedMembers(allNodeInformation, currentHeartbeatTime);
                 nextState = NodeState.COORDINATOR;
                 // notify nodes about coordinator change
                 List<String> nodeIdentifiers = new ArrayList<>();

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSMemberEventListenerTask.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSMemberEventListenerTask.java
@@ -152,7 +152,6 @@ class RDBMSMemberEventListenerTask implements Runnable {
                 }
             }
         }
-        communicationBusContext.removeRecordsOfRemovedMemberDetails(nodeID, groupId, member);
     }
 
     /**

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSMemberEventListenerTask.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSMemberEventListenerTask.java
@@ -152,6 +152,7 @@ class RDBMSMemberEventListenerTask implements Runnable {
                 }
             }
         }
+        communicationBusContext.removeRecordsOfRemovedMemberDetails(nodeID, groupId, member);
     }
 
     /**

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSMemberEventListenerTask.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/RDBMSMemberEventListenerTask.java
@@ -144,10 +144,10 @@ class RDBMSMemberEventListenerTask implements Runnable {
      * @param member The node ID of the event occured
      */
     private void notifyMemberRemovalEvent(String member, String groupId) {
-        for (MemberEventListener listener : listeners) {
-            if (listener.getGroupId().equals(groupId)) {
-                NodeDetail nodeDetail = communicationBusContext.getRemovedNodeData(nodeID, groupId, member);
-                if (nodeDetail != null) {
+        NodeDetail nodeDetail = communicationBusContext.getRemovedNodeData(nodeID, groupId, member);
+        if (nodeDetail != null) {
+            for (MemberEventListener listener : listeners) {
+                if (listener.getGroupId().equals(groupId)) {
                     listener.memberRemoved(nodeDetail);
                 }
             }

--- a/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/beans/StrategyConfig.java
+++ b/components/cluster-coordinator/org.wso2.carbon.cluster.coordinator/org.wso2.carbon.cluster.coordinator.rdbms/src/main/java/org/wso2/carbon/cluster/coordinator/rdbms/beans/StrategyConfig.java
@@ -29,9 +29,9 @@ import java.util.List;
 public class StrategyConfig {
 
     private String datasource;
-    private int heartbeatInterval = 1000;
-    private int heartbeatMaxRetry = 2;
-    private int eventPollingInterval = 1000;
+    private int heartbeatInterval = 5000;
+    private int heartbeatMaxRetry = 3;
+    private int eventPollingInterval = 5000;
 
     @Element(description = "Database query map")
     private List<Queries> queries;


### PR DESCRIPTION
## Purpose
> To make all task which is done at a time contain the same timestamp
> Add debug logs for the db tasks
> Allow member removed event to be sent to all registered listeners
> Change heartbeatInterval = 5000; heartbeatMaxRetry = 3; eventPollingInterval = 5000; as per the perf tests done

## Approach
> Create a manual scheduler and pass the schedule starting timestamp to all sub methods of the coordinator and member tasks

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes